### PR TITLE
Change SwerveProfiles to Accept Gyro Object

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -54,7 +54,7 @@ public class RobotContainer {
     // SwerveDriveProfile activeProfile = SwerveProfiles.OFF_SEASON_SWERVE;
 
     if (Robot.isReal()) {
-      gyro = new GyroNavX();
+      gyro = SwerveConfig.gyro;
 
       driveSub = new DrivetrainSubsystem(new MAXSwerveModule[] {
           new MAXSwerveModule(

--- a/src/main/java/frc/robot/subsystems/Drivetrain/GyroNavX.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain/GyroNavX.java
@@ -4,6 +4,8 @@
 package frc.robot.subsystems.Drivetrain;
 
 import com.studica.frc.AHRS;
+import com.studica.frc.AHRS.NavXComType;
+
 import edu.wpi.first.math.geometry.Rotation2d;
 import frc.robot.util.swerve.SwerveConfig;
 
@@ -15,8 +17,8 @@ public class GyroNavX implements Gyro {
 
   // SpongeBot
 
-  public GyroNavX() {
-    gyro = new AHRS(SwerveConfig.kGyroComType);
+  public GyroNavX(NavXComType comType) {
+    gyro = new AHRS(comType);
   }
 
   /**

--- a/src/main/java/frc/robot/util/swerve/SwerveConfig.java
+++ b/src/main/java/frc/robot/util/swerve/SwerveConfig.java
@@ -22,6 +22,7 @@ import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.ModuleConstants;
+import frc.robot.subsystems.Drivetrain.Gyro;
 import frc.robot.util.swerve.SwerveDriveProfile.SwerveDriveProfileID;
 
 public final class SwerveConfig {
@@ -30,7 +31,7 @@ public final class SwerveConfig {
   // the robot, rather the allowed maximum speeds
   public static SwerveDriveProfileID profileId; // 1: Comp 2: SpongeBot 3: OffSeasonSwerve
 
-  public static NavXComType kGyroComType;
+  public static Gyro gyro;
 
   public static RobotConfig kRobotConfig;
 
@@ -78,7 +79,7 @@ public final class SwerveConfig {
     SwerveConfig.profileId = profile.profileId();
 
     // Apply new Gyro
-    SwerveConfig.kGyroComType = profile.gyroComType();
+    SwerveConfig.gyro = profile.gyro();
 
     // Apply speed and dimension constants
     SwerveConfig.kMaxSpeed = profile.maxSpeedMps();

--- a/src/main/java/frc/robot/util/swerve/SwerveDriveProfile.java
+++ b/src/main/java/frc/robot/util/swerve/SwerveDriveProfile.java
@@ -42,7 +42,7 @@ public record SwerveDriveProfile(
     Distance bumperWidth,
     Mass robotMass,
     MomentOfInertia robotMOI,
-    NavXComType gyroComType,
+    Gyro gyro,
     SwerveDriveProfileID profileId) {
 
   public static enum SwerveDriveProfileID {
@@ -72,7 +72,7 @@ public record SwerveDriveProfile(
       Meters.of(0.75),
       Kilograms.of(74.088), // PathPlanner default, not accurate
       KilogramSquareMeters.of(6.883), // PathPlanner default, not accurate
-      NavXComType.kMXP_SPI,
+      new GyroNavX(NavXComType.kMXP_SPI),
       SwerveDriveProfileID.COMP_BOT);
 
   public static final SwerveDriveProfile SPONGE_BOT = new SwerveDriveProfile(
@@ -93,7 +93,7 @@ public record SwerveDriveProfile(
       Meters.of(0.75),
       Kilograms.of(74.088), // PathPlanner default, not accurate
       KilogramSquareMeters.of(6.883), // PathPlanner default, not accurate
-      NavXComType.kUSB1,
+      new GyroNavX(NavXComType.kUSB1),
       SwerveDriveProfileID.SPONGE_BOT);
 
   /**
@@ -115,7 +115,7 @@ public record SwerveDriveProfile(
       Meters.of(0.75),
       Kilograms.of(74.088), // PathPlanner default, not accurate
       KilogramSquareMeters.of(6.883), // PathPlanner default, not accurate
-      NavXComType.kMXP_SPI,
+      new GyroADXRS450(),
       SwerveDriveProfileID.OFF_SEASON_SWERVE);
 
   public String getName() {


### PR DESCRIPTION
_Authored by Elliott S._
**Changes:**
SwerveProfile constructors require gyro object instead of com type