### PR TITLE
Change SwerveDriveProfiles to Require GyroType Enums

### DIFF
--- a/src/main/java/frc/robot/util/swerve/SwerveConfig.java
+++ b/src/main/java/frc/robot/util/swerve/SwerveConfig.java
@@ -20,9 +20,13 @@ import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
+import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.ModuleConstants;
 import frc.robot.subsystems.Drivetrain.Gyro;
+import frc.robot.subsystems.Drivetrain.GyroADXRS450;
+import frc.robot.subsystems.Drivetrain.GyroNavX;
+import frc.robot.subsystems.Drivetrain.GyroNavX;
 import frc.robot.util.swerve.SwerveDriveProfile.SwerveDriveProfileID;
 
 public final class SwerveConfig {
@@ -79,7 +83,12 @@ public final class SwerveConfig {
     SwerveConfig.profileId = profile.profileId();
 
     // Apply new Gyro
-    SwerveConfig.gyro = profile.gyro();
+    SwerveConfig.gyro = switch (profile.gyro()) {
+      case ADXRS450 -> new GyroADXRS450();
+      case NavX_MXP_SPI -> new GyroNavX(NavXComType.kMXP_SPI);
+      case NavX_USB1 -> new GyroNavX(NavXComType.kUSB1);
+      default -> new GyroNavX(NavXComType.kMXP_SPI);
+    };
 
     // Apply speed and dimension constants
     SwerveConfig.kMaxSpeed = profile.maxSpeedMps();

--- a/src/main/java/frc/robot/util/swerve/SwerveDriveProfile.java
+++ b/src/main/java/frc/robot/util/swerve/SwerveDriveProfile.java
@@ -42,13 +42,19 @@ public record SwerveDriveProfile(
     Distance bumperWidth,
     Mass robotMass,
     MomentOfInertia robotMOI,
-    Gyro gyro,
+    GyroType gyro,
     SwerveDriveProfileID profileId) {
 
   public static enum SwerveDriveProfileID {
     COMP_BOT,
     SPONGE_BOT,
     OFF_SEASON_SWERVE
+  }
+
+  public static enum GyroType {
+    NavX_MXP_SPI,
+    NavX_USB1,
+    ADXRS450
   }
 
   /**
@@ -72,7 +78,7 @@ public record SwerveDriveProfile(
       Meters.of(0.75),
       Kilograms.of(74.088), // PathPlanner default, not accurate
       KilogramSquareMeters.of(6.883), // PathPlanner default, not accurate
-      new GyroNavX(NavXComType.kMXP_SPI),
+      GyroType.NavX_MXP_SPI,
       SwerveDriveProfileID.COMP_BOT);
 
   public static final SwerveDriveProfile SPONGE_BOT = new SwerveDriveProfile(
@@ -93,7 +99,7 @@ public record SwerveDriveProfile(
       Meters.of(0.75),
       Kilograms.of(74.088), // PathPlanner default, not accurate
       KilogramSquareMeters.of(6.883), // PathPlanner default, not accurate
-      new GyroNavX(NavXComType.kUSB1),
+      GyroType.NavX_USB1,
       SwerveDriveProfileID.SPONGE_BOT);
 
   /**
@@ -115,7 +121,7 @@ public record SwerveDriveProfile(
       Meters.of(0.75),
       Kilograms.of(74.088), // PathPlanner default, not accurate
       KilogramSquareMeters.of(6.883), // PathPlanner default, not accurate
-      new GyroADXRS450(),
+      GyroType.ADXRS450,
       SwerveDriveProfileID.OFF_SEASON_SWERVE);
 
   public String getName() {


### PR DESCRIPTION
_Co-authored by Elliott S_

Instead of instantiating the gyro objects, GyroType enums are passed into the Swerve Profiles.