### PR TITLE
Add All Vision Simulation Settings As Optional Camera Profile Parameters

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -28,6 +28,8 @@ import com.pathplanner.lib.path.PathConstraints;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.Vector;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -36,7 +38,9 @@ import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N8;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
@@ -223,12 +227,34 @@ public final class Constants {
     // Maple sim provides 2d simulation, and cannot simulate the bump accurately,
     // it can be either a wall or non-existant
     public static final boolean kSimBumpCollision = false;
+
+    // Default vision properties
+    public static final File kSimVisionConfigurationFile = new File(Filesystem.getDeployDirectory().getPath(),
+        "simulated_camera_settings\\arducam_OV9281_calibration_1280x720.json");
+    public static final double kSimVisionFPS = 20;
+    public static final Time kSimVisionLatency = Milliseconds.of(40);
+    public static final Time kSimVisionLatencyDeviation = Milliseconds.of(5);
+    public static final Angle kSimVisionFOV = Degrees.of(70);
+    public static final int[] kSimVisionResolution = { 1280, 720 };
+    public static final Matrix<N3, N3> kSimVisionIntrinsics = MatBuilder.fill(N3.instance, N3.instance,
+        940.7360710926395,
+        0.0,
+        615.5884770322365,
+        0.0,
+        939.9932393907364,
+        328.53938300868,
+        0.0,
+        0.0,
+        1.0);
+    public static final Matrix<N8, N1> kSimVisionDistCoeffs = MatBuilder.fill(N8.instance, N1.instance,
+        0.054834081023049625,
+        -0.15994111706817074,
+        -0.0017587106009926158,
+        -0.0014671022483263552,
+        0.049742166267499596, 0, 0, 0);
   }
 
   public static final class PhotonConstants {
-    public static final File kCalibrationFile = new File(Filesystem.getDeployDirectory().getPath(),
-        "simulated_camera_settings\\arducam_OV9281_calibration_1280x720.json");
-
     // Camera profiles - each camera's configuration in one place
     public static final CameraProfile kCamera1Profile = new CameraProfile(
         "Arducam_1",
@@ -238,14 +264,7 @@ public final class Constants {
         Meters.of(0.307), // x
         Meters.of(0.180), // y
         Meters.of(0.750), // z
-        VecBuilder.fill(0.3, 0.3, 0.3), // standard deviation);
-        kCalibrationFile, // Calibration file
-        30, // FPS
-        Milliseconds.of(20), // Latency
-        Milliseconds.of(5), // Latency deviation
-        Degrees.of(70), // FOV
-        new int[] { 1280, 720 } // Resolution
-    );
+        VecBuilder.fill(0.3, 0.3, 0.3));
 
     public static final CameraProfile kCamera2Profile = new CameraProfile(
         "Arducam_2",
@@ -255,14 +274,7 @@ public final class Constants {
         Meters.of(0.238), // x
         Meters.of(-0.294), // y
         Meters.of(0.625), // z
-        VecBuilder.fill(0.9, 0.9, 0.9), // standard deviation
-        kCalibrationFile, // Calibration file
-        30, // FPS
-        Milliseconds.of(20), // Latency
-        Milliseconds.of(5), // Latency deviation
-        Degrees.of(70), // FOV
-        new int[] { 1280, 720 } // Resolution
-    );
+        VecBuilder.fill(0.9, 0.9, 0.9));
 
     public static final CameraProfile kCamera3Profile = new CameraProfile(
         "Arducam_3",
@@ -272,14 +284,7 @@ public final class Constants {
         Meters.of(-0.3327), // x
         Meters.of(0.0), // y
         Meters.of(0.3708), // z
-        VecBuilder.fill(0.5, 0.5, 0.5), // standard deviation
-        kCalibrationFile, // Calibration file
-        30, // FPS
-        Milliseconds.of(40), // Latency
-        Milliseconds.of(5), // Latency deviation
-        Degrees.of(70), // FOV
-        new int[] { 1280, 720 } // Resolution
-    );
+        VecBuilder.fill(0.5, 0.5, 0.5));
 
     public static final int kAprilTagPipeline = 0;
 

--- a/src/main/java/frc/robot/subsystems/Drivetrain/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain/DrivetrainSubsystem.java
@@ -164,10 +164,10 @@ public class DrivetrainSubsystem extends SubsystemBase {
 
         SimCameraProperties simulatedProperties;
         try {
-          if (currentProfile.calibrationFile() == null) {
-            throw new IOException("No calibration file specified in camera profile.");
+          if (currentProfile.configFile() == null || !currentProfile.configFile().exists()) {
+            throw new IOException("No calibration file specified in camera profile or file does not exist.");
           }
-          simulatedProperties = new SimCameraProperties(currentProfile.calibrationFile().getPath(),
+          simulatedProperties = new SimCameraProperties(currentProfile.configFile().getPath(),
               currentProfile.resolution()[0], currentProfile.resolution()[1]);
 
         } catch (IOException e) {
@@ -176,14 +176,24 @@ public class DrivetrainSubsystem extends SubsystemBase {
                   + ", falling back to setting set by camera profile. Error: " +
                   e.getMessage());
           simulatedProperties = new SimCameraProperties();
-          simulatedProperties.setCalibration(currentProfile.resolution()[0], currentProfile.resolution()[1],
-              new Rotation2d(currentProfile.fieldOfView()));
+          if (currentProfile.camIntrinsics() == null || currentProfile.distCoeffs() == null) {
+            System.out.println("Could not find camera matrices for camera profile " + i + ", reverting to set FOV.");
+            simulatedProperties.setCalibration(currentProfile.resolution()[0], currentProfile.resolution()[1],
+                new Rotation2d(currentProfile.fieldOfView()));
+          } else {
+            simulatedProperties.setCalibration(currentProfile.resolution()[0], currentProfile.resolution()[1],
+                currentProfile.camIntrinsics(),
+                currentProfile.distCoeffs());
+          }
           simulatedProperties.setFPS(currentProfile.fps());
           simulatedProperties.setAvgLatencyMs(currentProfile.avgLatency().in(Milliseconds));
           simulatedProperties.setLatencyStdDevMs(currentProfile.avgLatencyDeviation().in(Milliseconds));
         }
 
         PhotonCameraSim simulatedCamera = new PhotonCameraSim(cameras[i], simulatedProperties);
+        simulatedCamera.enableRawStream(true);
+        simulatedCamera.enableProcessedStream(true);
+        simulatedCamera.enableDrawWireframe(currentProfile.simulationWireframeEnabled());
         simulatedVision.addCamera(simulatedCamera, currentProfile.getRobotToCameraTransform());
       }
 
@@ -992,7 +1002,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
     if (this.simulatedSwerveDrive != null) {
       Pose2d simulatedPose = simulatedSwerveDrive.getSimulatedDriveTrainPose();
       if (this.simulatedVision != null) {
-        this.simulatedVision.update(simulatedPose);
+        simulatedVision.update(simulatedPose);
       }
       Logger.recordOutput("FieldSimulation/PhysicalRobotPose", simulatedPose);
     }

--- a/src/main/java/frc/robot/util/vision/CameraProfile.java
+++ b/src/main/java/frc/robot/util/vision/CameraProfile.java
@@ -1,46 +1,59 @@
 package frc.robot.util.vision;
 
-import static edu.wpi.first.units.Units.Degrees;
-import static edu.wpi.first.units.Units.Milliseconds;
-
 import java.io.File;
 
+import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Vector;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-
+import edu.wpi.first.math.numbers.N8;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Time;
+import frc.robot.Constants.SimulationConstants;
 
 /**
  * Record class representing a camera configuration profile.
  * Contains all the necessary parameters to configure a camera.
  *
- * @param name                The camera name/identifier
- * @param roll                Rotation around x-axis in radians
- * @param pitch               Rotation around y-axis in radians
- * @param yaw                 Rotation around z-axis in radians
- * @param x                   Translation in x-direction (meters, +x is forward)
- * @param y                   Translation in y-direction (meters, +y is left)
- * @param z                   Translation in z-direction (meters, +z is up)
- * @param standardDeviation   Standard deviations for vision measurements [x, y,
- *                            theta]
- * @param calibrationFile     [OPTIONAL] PhotonVision calibration file for
- *                            simulation
- *                            purposes (.json)
- * @param fps                 [OPTIONAL] Frames per second for simulation
- *                            purposes
- * @param avgLatency          [OPTIONAL] Average latency for simulation purposes
- * @param avgLatencyDeviation [OPTIONAL] Max deviation from average latency for
- *                            simulation
- *                            purposes
- * @param fieldOfView         [OPTIONAL] Diagonal field of view for simulation
- *                            purposes
- * @param resolution          [OPTIONAL] Video resolution for simulation
- *                            purposes
+ * @param name                       The camera name/identifier
+ * @param roll                       Rotation around x-axis in radians
+ * @param pitch                      Rotation around y-axis in radians
+ * @param yaw                        Rotation around z-axis in radians
+ * @param x                          Translation in x-direction (meters, +x is
+ *                                   forward)
+ * @param y                          Translation in y-direction (meters, +y is
+ *                                   left)
+ * @param z                          Translation in z-direction (meters, +z is
+ *                                   up)
+ * @param standardDeviation          Standard deviations for vision measurements
+ *                                   [x, y,
+ *                                   theta]
+ * @param configFile                 [OPTIONAL] PhotonVision config file for
+ *                                   simulation purposes (config.json)
+ * @param fps                        [OPTIONAL] Frames per second for simulation
+ *                                   purposes
+ * @param avgLatency                 [OPTIONAL] Average latency for simulation
+ *                                   purposes
+ * @param avgLatencyDeviation        [OPTIONAL] Max deviation from average
+ *                                   latency for
+ *                                   simulation
+ *                                   purposes
+ * @param fieldOfView                [OPTIONAL] Diagonal field of view for
+ *                                   simulation
+ *                                   purposes
+ * @param resolution                 [OPTIONAL] Video resolution for simulation
+ *                                   purposes
+ * @param camIntrinsics              [OPTIONAL] Camera instrinsics for
+ *                                   simulation
+ * @param distCoeffs                 [OPTIONAL] Distortion coeffients for
+ *                                   simulation
+ * @param simulationWireframeEnabled [OPTIONAL] Simulate wireframe, usually
+ *                                   false due
+ *                                   to being extremely resource-heavy
  */
 public record CameraProfile(
     String name,
@@ -51,26 +64,18 @@ public record CameraProfile(
     Distance y,
     Distance z,
     Vector<N3> standardDeviation,
-    File calibrationFile,
+    File configFile,
     double fps,
     Time avgLatency,
     Time avgLatencyDeviation,
     Angle fieldOfView,
-    int[] resolution) {
+    int[] resolution,
+    Matrix<N3, N3> camIntrinsics,
+    Matrix<N8, N1> distCoeffs,
+    boolean simulationWireframeEnabled) {
 
   /**
-   * Record class representing a camera configuration profile.
-   * Contains all the necessary parameters to configure a camera.
-   *
-   * @param name              The camera name/identifier
-   * @param roll              Rotation around x-axis in radians
-   * @param pitch             Rotation around y-axis in radians
-   * @param yaw               Rotation around z-axis in radians
-   * @param x                 Translation in x-direction (meters, +x is forward)
-   * @param y                 Translation in y-direction (meters, +y is left)
-   * @param z                 Translation in z-direction (meters, +z is up)
-   * @param standardDeviation Standard deviations for vision measurements [x, y,
-   *                          theta]
+   * {@inheritDoc}
    */
   public CameraProfile(String name,
       Angle roll,
@@ -80,8 +85,54 @@ public record CameraProfile(
       Distance y,
       Distance z,
       Vector<N3> standardDeviation) {
-    this(name, roll, pitch, yaw, x, y, z, standardDeviation, null, 17, Milliseconds.of(20), Milliseconds.of(5),
-        Degrees.of(70), new int[] { 1280, 720 });
+    this(name, roll, pitch, yaw, x, y, z, standardDeviation, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public CameraProfile(String name,
+      Angle roll,
+      Angle pitch,
+      Angle yaw,
+      Distance x,
+      Distance y,
+      Distance z,
+      Vector<N3> standardDeviation, boolean simulationWireframeEnabled) {
+    this(name, roll, pitch, yaw, x, y, z, standardDeviation, null, simulationWireframeEnabled);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public CameraProfile(String name,
+      Angle roll,
+      Angle pitch,
+      Angle yaw,
+      Distance x,
+      Distance y,
+      Distance z,
+      Vector<N3> standardDeviation,
+      File configFile) {
+    this(name, roll, pitch, yaw, x, y, z, standardDeviation, configFile, false);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public CameraProfile(String name,
+      Angle roll,
+      Angle pitch,
+      Angle yaw,
+      Distance x,
+      Distance y,
+      Distance z,
+      Vector<N3> standardDeviation,
+      File configFile, boolean simulationWireframeEnabled) {
+    this(name, roll, pitch, yaw, x, y, z, standardDeviation, configFile, SimulationConstants.kSimVisionFPS,
+        SimulationConstants.kSimVisionLatency, SimulationConstants.kSimVisionLatencyDeviation,
+        SimulationConstants.kSimVisionFOV, SimulationConstants.kSimVisionResolution,
+        SimulationConstants.kSimVisionIntrinsics, SimulationConstants.kSimVisionDistCoeffs, simulationWireframeEnabled);
   }
 
   /**


### PR DESCRIPTION
**Changes:**
Vision is simulated, and can now be modified directly from Constants.java by modifying the CameraProfile instantiations. Default settings are located inside of the SimulationConstants subclass, and cameras will always try to access the configuration JSON before falling back to hard-specified settings. These constants will not be forced onto the user, as they can be avoided by using additional convenience constructors in the CameraProfile that will automatically utilize default settings.

**Affects:**
- Drivetrain Subsystem's Constructor
- Camera Profiles
- Simulation Constants
- PhotonVision Constants

**Testing:**
- Tested on AdvantageScope (Windows 11)
- Wireframe feed can be viewed through telemetry application like Elastic