### PR TITLE
Define test mode behavior, using a LoggedNetworkNumber to adjust laun…

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -161,7 +161,7 @@ public final class Constants {
       return RPM.of(rpm * kRPMCurveMultiplier.getAsDouble());
     };
 
-    public static final Distance kMinLaunchDistance;
+    public static final Distance kMinLaunchDistance = Meters.of(1.8);
 
     static {
       // Minimum vertical velocity needed to reach hub height (from energy
@@ -193,7 +193,9 @@ public final class Constants {
           ? (-b + Math.sqrt(discriminant)) / (2 * a)
           : 1.5; // fallback if curve never reaches minOmegaRPM
 
-      kMinLaunchDistance = Meters.of(Math.max(0, minDist));
+      // These calculations are not accurate enough, stick with a predetermined
+      // constant
+      // kMinLaunchDistance = Meters.of(Math.max(0, minDist));
       Logger.recordOutput("Commands/LauncherCmd/MinLaunchDistance", kMinLaunchDistance);
     }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -659,10 +659,10 @@ public final class Constants {
 
     static {
       kConfigLeft.smartCurrentLimit((int) kSmartCurrentLimit.in(Amps));
-      kConfigLeft.inverted(false); // TODO: Plug in one motor at a time and run ClimbPercentCmd with a small
-                                   // positive value like 0.1. Watch which direction the arm moves: If it goes up,
-                                   // that motor needs inverted(false) If it goes down, that motor needs
-                                   // inverted(true)
+      kConfigLeft.inverted(true); // TODO: Plug in one motor at a time and run ClimbPercentCmd with a small
+                                  // positive value like 0.1. Watch which direction the arm moves: If it goes up,
+                                  // that motor needs inverted(false) If it goes down, that motor needs
+                                  // inverted(true)
       kConfigLeft.encoder.positionConversionFactor(kRotationsToInchesConversion);
       kConfigLeft.voltageCompensation(12.0);
       kConfigLeft.closedLoop

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -130,8 +130,7 @@ public final class Constants {
     public static final Distance kWheelRadius = Inches.of(2);
     // Empirical constant describing the ratio between wheel linear velocity and
     // ball launch velocity
-    // TODO determine from video data
-    public static final double kWheelSlipCoefficient = 0.4;
+    public static final double kWheelSlipCoefficient = 0.436;
 
     public static final int kLeaderCanSparkId = 9;
     public static final int kFollowerCanSparkId = 10;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -149,13 +149,13 @@ public final class Constants {
     public static final Distance kLaunchLookupTolerance = Meters.of(0.1);
 
     // Found using polynomial regression (degree 2)
-    private static final double kRPMCurveA = 43.5;
-    private static final double kRPMCurveB = 119;
-    private static final double kRPMCurveC = 2372;
+    private static final double kRPMCurveA = 69.9;
+    private static final double kRPMCurveB = -143;
+    private static final double kRPMCurveC = 2640;
     // For fine tuning due to small changes
     // TODO replace with final value after testing
     private static final LoggedNetworkNumber kRPMCurveMultiplier = new LoggedNetworkNumber("/Tuning/RPMCurveMultiplier",
-        0.963);
+        1.0);
     public static final Function<Distance, AngularVelocity> kDistanceToRPMCurve = (Distance distance) -> {
       double d = distance.in(Meters);
       double rpm = kRPMCurveA * d * d + kRPMCurveB * d + kRPMCurveC;
@@ -218,9 +218,9 @@ public final class Constants {
     public static final AngularVelocity kIntakeRPMSetpoint = RPM.of(1000);
     public static final AngularVelocity kPassRPMSetpoint = RPM.of(4500);
     // Visionless backup setpoints
-    public static final AngularVelocity kBumpRPMSetpoint = RPM.of(2750);
-    public static final AngularVelocity kTrenchRPMSetpoint = RPM.of(3390);
-    public static final AngularVelocity kTowerRPMSetpoint = RPM.of(3190);
+    public static final AngularVelocity kBumpRPMSetpoint = RPM.of(2500);
+    public static final AngularVelocity kTrenchRPMSetpoint = RPM.of(3020);
+    public static final AngularVelocity kTowerRPMSetpoint = RPM.of(2910);
     public static final AngularVelocity kCornerRPMSetpoint = kDistanceToRPMCurve.apply(Meters.of(5.4539));
     // RPM increment per second when doing manual offset
     public static final AngularVelocity kManualRPMOffsetPerSecond = RPM.of(50);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -177,6 +177,7 @@ public class Robot extends LoggedRobot {
   public void testInit() {
     // Cancels all running commands at the start of test mode.
     CommandScheduler.getInstance().cancelAll();
+    m_robotContainer.configureTestMode();
   }
 
   /** This function is called periodically during test mode. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -497,7 +497,8 @@ public class RobotContainer {
         OIConstants.kTestControllerPort);
     final LoggedNetworkNumber testRPM = new LoggedNetworkNumber("/Tuning/testRPM", 1000);
 
-    testController.a().whileTrue(new LauncherCmd(launcherAndIntakeSub, () -> RPM.of(testRPM.get())));
+    testController.a()
+        .whileTrue(new LaunchAndIndexCmd(indexerSub, launcherAndIntakeSub, () -> true, () -> RPM.of(testRPM.get())));
   }
 
   // Helper methods to reduce repetition

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -28,6 +28,7 @@ import org.ironmaple.simulation.drivesims.SwerveDriveSimulation;
 import org.ironmaple.simulation.drivesims.configs.DriveTrainSimulationConfig;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.LoggedDashboardChooser;
+import org.littletonrobotics.junction.networktables.LoggedNetworkNumber;
 
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
@@ -96,8 +97,8 @@ public class RobotContainer {
       OIConstants.kDriverControllerPort);
   private final CommandXboxController operatorController = new CommandXboxController(
       OIConstants.kOperatorControllerPort);
-  private final CommandXboxController testController = new CommandXboxController(
-      OIConstants.kTestControllerPort);
+  // Only initialize in test mode
+  private CommandXboxController testController;
 
   private LoggedDashboardChooser<Command> autoChooser, debugChooser;
 
@@ -325,25 +326,10 @@ public class RobotContainer {
 
     driveSub.setDefaultCommand(driveCmd);
 
-    indexerSub
-        .setDefaultCommand(new IndexerCmd(indexerSub, () -> testController.getLeftY() * IndexerConstants.kWheelSpeed,
-            () -> testController.getRightY() * IndexerConstants.kTreadmillSpeed));
-
     // Negate so up is positive
     climberSub.setDefaultCommand(new ClimbPercentCmd(climberSub,
         () -> MathUtil.applyDeadband(-operatorController.getLeftY(),
             OIConstants.kDeadband)));
-
-    // Left arm only: left stick Y on test controller
-    testController.povLeft().whileTrue(new ClimbPercentCmd(climberSub, () -> testController.getLeftY() * 0.1));
-
-    // Right arm only: right stick Y on test controller
-    testController.povRight().whileTrue(new ClimbPercentCmd(climberSub, () -> testController.getRightY() * 0.1));
-
-    // Both arms together; verify they move in the same direction
-    testController.povUp().whileTrue(new ClimbPercentCmd(climberSub, () -> 0.1)); // should both go up
-
-    testController.povDown().whileTrue(new ClimbPercentCmd(climberSub, () -> -0.1)); // should both go down
 
     driverController.a().toggleOnTrue(new DriveLockedHeadingCmd(driveSub, this::getDriverVx, this::getDriverVy,
         new Rotation2d(DriveConstants.kBumpHeadingRestriction), DriveConstants.kBumpLinearVelocity));
@@ -503,9 +489,15 @@ public class RobotContainer {
     }));
 
     operatorController.rightStick().onTrue(Commands.runOnce(() -> launcherAndIntakeSub.resetVelocityOffset()));
+  }
 
-    testController.x().whileTrue(new DriveToTowerSideCmd(driveSub, TowerSide.Left));
-    testController.b().whileTrue(new DriveToTowerSideCmd(driveSub, TowerSide.Right));
+  /** Run in {@code Robot.testInit()} */
+  public void configureTestMode() {
+    testController = new CommandXboxController(
+        OIConstants.kTestControllerPort);
+    final LoggedNetworkNumber testRPM = new LoggedNetworkNumber("/Tuning/testRPM", 1000);
+
+    testController.a().whileTrue(new LauncherCmd(launcherAndIntakeSub, () -> RPM.of(testRPM.get())));
   }
 
   // Helper methods to reduce repetition

--- a/src/main/java/frc/robot/commands/indexer/TreadmillOnCmd.java
+++ b/src/main/java/frc/robot/commands/indexer/TreadmillOnCmd.java
@@ -36,6 +36,7 @@ public class TreadmillOnCmd extends Command {
   @Override
   public void end(boolean interrupted) {
     Logger.recordOutput("Commands/IndexerCmd/TreadmillPulse", false);
+    indexer.stop();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Drivetrain/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain/DrivetrainSubsystem.java
@@ -1052,6 +1052,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
     Logger.recordOutput("Drivetrain/Swerve/Module/State", states);
     Logger.recordOutput("Drivetrain/Swerve/Module/Position", positions);
     Logger.recordOutput("Drivetrain/HubBotReative", getHubTranslation3dBotRelative());
+    Logger.recordOutput("Drivetrain/HubDistance2d", getHubTranslation3dBotRelative().toTranslation2d().getNorm());
 
     // Retrieve SmartDashboard settings
     if (simulatedSwerveDrive != null) {

--- a/src/main/java/frc/robot/util/launcher/LaunchHelpers.java
+++ b/src/main/java/frc/robot/util/launcher/LaunchHelpers.java
@@ -93,13 +93,13 @@ public class LaunchHelpers {
     // Find 2d translation of flight path
     Translation2d ball2DTranslationMeters = ballInitialVelocityMPS.times(airTime.in(Seconds)).toTranslation2d();
 
-    // Rotate to launch in the correct direction
-    ball2DTranslationMeters = new Translation2d(
-        ball2DTranslationMeters.getNorm(),
-        drive().getPose().getRotation().minus(LauncherAndIntakeConstants.kLauncherBotHeading));
+    // // Rotate to launch in the correct direction
+    // ball2DTranslationMeters = new Translation2d(
+    // ball2DTranslationMeters.getNorm(),
+    // drive().getPose().getRotation().minus(LauncherAndIntakeConstants.kLauncherBotHeading));
 
     // Add to current pose, and add back the z component
-    return new Translation3d(drive().getPose().getTranslation().plus(ball2DTranslationMeters))
+    return new Translation3d(botPose.getTranslation().plus(ball2DTranslationMeters))
         .plus(new Translation3d(0, 0, targetHeight.in(Meters)));
   }
 
@@ -169,10 +169,9 @@ public class LaunchHelpers {
    *         before trying to shoot.
    */
   public static boolean isTooCloseToHub() {
-    double xDist = Math.abs(
-        drive().getPose().getX() - PoseHelpers.getAllianceHubtTranslation2d().getX());
-    boolean tooClose = Meters.of(xDist).lt(LauncherAndIntakeConstants.kMinLaunchDistance);
-    Logger.recordOutput("Launcher/TooClose/XDist", xDist);
+    double dist = drive().getPose().getTranslation().getDistance(PoseHelpers.getAllianceHubtTranslation2d());
+    boolean tooClose = Meters.of(dist).lt(LauncherAndIntakeConstants.kMinLaunchDistance);
+    Logger.recordOutput("Launcher/TooClose/Dist", dist);
     Logger.recordOutput("Launcher/TooClose/IsTooClose", tooClose);
     return tooClose;
   }
@@ -323,7 +322,7 @@ public class LaunchHelpers {
         .rotateBy(new Rotation3d(LauncherAndIntakeConstants.kLauncherBotHeading));
 
     // Field relative coordinates
-    launchVelocity = launchVelocity.rotateBy(new Rotation3d(drive().getPose().getRotation().unaryMinus()));
+    launchVelocity = launchVelocity.rotateBy(new Rotation3d(drive().getPose().getRotation()));
 
     return launchVelocity;
   }


### PR DESCRIPTION
This branch should be used to retune the launcher RPM curve. The test controller will no longer be initialized outside of test mode. So it is important to be in test mode when tuning.

### Here is the process to test:

- [ ] Ensure that the robot can determine its distance from the hub, this may require covering non-hub tags
- [ ] Run the code in test mode (select "Test" in driver station) and open advantage kit with tuning mode enabled (click the icon beside the search bar to turn it purple)
        <img width="300" height="73" alt="Screenshot 2026-03-26 at 9 39 26 AM" src="https://github.com/user-attachments/assets/3d0e2368-6902-46cc-8e70-c29b8063881a" />
- [ ]  Open [this spreadsheet](https://docs.google.com/spreadsheets/d/1duzXlp1usGZft4t0U8dqlPHNa6MvUlqzno3oAQYQhoo/edit?gid=0#gid=0) and navigate to the "Retune" sheet

### For each distance:

- [ ] Move to the bot so that ``/RealOutputs/Drivetrain/HubDistance2d`` is equal to the distance, align the heading manually
- [ ] Tune the RPM value under ``/Tuning/TestRPM``, and hold 'a' on the testController until the balls go in consistently
- [ ] Record the RPM setpoint in the spreadsheet
- [ ] Record a short video of launching 2-4 balls with the correct RPM, keeping the ball in view the whole time. Change the title to the distance setpoint name or value (ex: Bump, Trench, 2.5m), upload the video [here](https://drive.google.com/drive/folders/1anetxtgp-xCI4M1tB2-AXrIFUVfXey7Z)

### After tuning

- [ ] Update the coefficients and visionless setpoints in the code
- [ ] Test the robot in teleop mode to ensure it behaves as intended

The goal of the videos is to allow us to extract more data (such as a lookup table/curve for ball time of flight), without needing additional bot time